### PR TITLE
KT-210: Man skall inte behöva skriva ":" när man anger klockslag

### DIFF
--- a/Tolk.Web/Services/DateTimeOffsetModelBinder.cs
+++ b/Tolk.Web/Services/DateTimeOffsetModelBinder.cs
@@ -21,7 +21,10 @@ namespace Tolk.Web.Services
                 return Task.CompletedTask;
             }
 
-            var rawDateTime = DateTime.Parse($"{dateValue.FirstValue} {timeValue}");
+            var rawTime = timeValue.FirstValue.Contains(":") 
+                ? timeValue.FirstValue 
+                : timeValue.FirstValue.Insert(timeValue.FirstValue.Length - 2, ":"); // Add colon to time if not exists
+            var rawDateTime = DateTime.Parse($"{dateValue.FirstValue} {rawTime}");
 
             var model = rawDateTime.ToDateTimeOffsetSweden();
 

--- a/Tolk.Web/TagHelpers/FormEntryTagHelper.cs
+++ b/Tolk.Web/TagHelpers/FormEntryTagHelper.cs
@@ -272,8 +272,8 @@ namespace Tolk.Web.TagHelpers
                 {
                     @class = "form-control",
                     placeholder = "HH:MM",
-                    data_val_regex_pattern = "^(([0-1]?[0-9])|(2[0-3])):[0-5][0-9]$",
-                    data_val_regex = "Ange tid som HH:MM",
+                    data_val_regex_pattern = "^(([0-1]?[0-9])|(2[0-3])):?[0-5][0-9]$",
+                    data_val_regex = "Ange tid som HH:MM eller HHMM",
                     data_val_required = "Tid måste anges.",
                     data_val = true
                 });
@@ -345,8 +345,8 @@ namespace Tolk.Web.TagHelpers
                 {
                     @class = "form-control",
                     placeholder = "HH:MM",
-                    data_val_regex_pattern = "^(([0-1]?[0-9])|(2[0-3])):[0-5][0-9]$",
-                    data_val_regex = "Ange tid som HH:MM",
+                    data_val_regex_pattern = "^(([0-1]?[0-9])|(2[0-3])):?[0-5][0-9]$",
+                    data_val_regex = "Ange tid som HH:MM eller HHMM",
                     data_val_required = "Tid måste anges."
                 });
 


### PR DESCRIPTION
Det måste vara enklare/snabbare att ange klocklslag för starttid och sluttid. Man skall inte behöva skriva ett ":" mellan HH och MM, systemet bör förstå ändå om man skriver utan.