### PR TITLE
KT-200: Översta delen av arbetsytan skyms för användare med impersonation + klocka

### DIFF
--- a/Tolk.Web/Views/Shared/_LoginPartial.cshtml
+++ b/Tolk.Web/Views/Shared/_LoginPartial.cshtml
@@ -19,7 +19,7 @@
             {
                 <form id="impersonation-form" asp-area="" asp-controller="Account" asp-action="Impersonate" method="post" class="navbar-form navbar-right">
                     <div class="form-group">
-                        <select name="UserId" id="impersonation-select" asp-items="SelectListService.ImpersonationList" class="form-control"></select>
+                        <select name="UserId" id="impersonation-select" asp-items="SelectListService.ImpersonationList" class="form-control" style="width:200px"></select>
                     </div>
                 </form>
             }


### PR DESCRIPTION
Minskade bara bredden på impersonation dropdown från 274px till 200px. 

Bedömde att detta (i alla fall preliminärt) enbart kommer synas för oss utvecklare, samt när vi demar. En mer ordentlig overflowlösning kan implementeras om vi vill lägga ner lite mer tid på detta.